### PR TITLE
isHidden getting set to undefined in some cases

### DIFF
--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -166,10 +166,12 @@ module.exports = React.createClass({
     componentWillReceiveProps: function () {
       var self = this,
           options = self.props.items ? self.props.items[0] : false;
-
-      self.setState({
-        isHidden: options.hide
-      });
+      
+      if (options.hide !== undefined){
+        self.setState({
+          isHidden: options.hide
+        });
+      }
     },
 
     renderItem: function (item, index) {


### PR DESCRIPTION
I have yet to pin down the exact reason for this, but sometimes the componentWillReceiveProps function fires on page load and the isHidden state is set to undefined, which makes all the menus become visible at once.