### PR TITLE
add onchange callback

### DIFF
--- a/src/js/components/InputItem.js
+++ b/src/js/components/InputItem.js
@@ -93,6 +93,11 @@ module.exports = React.createClass({
         inputValue: inputValue,
         inputClasses: inputClasses
       });
+      
+      //return change to parent via callback
+      if (this.props.handleChange) {
+        this.props.handleChange(inputValue);
+      }
     },
 
     renderLabel: function () {


### PR DESCRIPTION
This will make it easier for parent components to access input value.  For example:

              <DialogItemContent>
                <Input>
                  <InputItem
                    classes={'e-input-group'}
                    inputClasses={'e-input empty'}
                    type='text'
                    name='label'
                    placeholder='Enter Value'
                    handleChange={this.getValue}
                    >
                  </InputItem>
                </Input>
              </DialogItemContent>