### PR TITLE
point to https for google font

### DIFF
--- a/src/less/essence/progress/progress.less
+++ b/src/less/essence/progress/progress.less
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Raleway:100);
+@import url(https://fonts.googleapis.com/css?family=Raleway:100);
 
 //three dots slider bar
 .e-progress-slider {


### PR DESCRIPTION
Now that SSL is encouraged for everyone and doesn’t have performance concerns, if the asset you need is available on SSL, then I feel you should always use the https:// asset. Thoughts?  This is causing mixed content blocking on our site unless I manually change the url to https.