### PR TITLE
Update counter.current when inputValue changes

### DIFF
--- a/src/js/components/InputItem.js
+++ b/src/js/components/InputItem.js
@@ -29,15 +29,18 @@ module.exports = React.createClass({
     _toggleAction: function(data) {
       var self = this,
           inputClasses = self.state.inputClasses,
-          inputValue = self.props.value || self.props.inputValue || self.state.inputValue || '';
+          inputValue = self.props.value || self.props.inputValue || self.state.inputValue || '',
+          counter = self.state.counter;
 
       if (data.action === "setValue") {
         if (self.props.name === data.id) {
           inputValue = data.value;
           inputClasses['empty'] = false;
+          counter.current = inputValue.length;
           self.setState({
             inputClasses: inputClasses,
-            inputValue: inputValue
+            inputValue: inputValue,
+            counter: counter
           });
         }
       }


### PR DESCRIPTION
When using the setValue action, the counter.current value is not changed to reflect the new length of the inputvalue variable.

I am making this on the cleanup branch because the _toggleAction function isn't in the master branch, and the cleanup branch seems to be the one your are releasing to NPM.   

Let me know if this makes sense to you.